### PR TITLE
Update miniconda2.rb

### DIFF
--- a/Casks/miniconda2.rb
+++ b/Casks/miniconda2.rb
@@ -13,8 +13,9 @@ cask 'miniconda2' do
   installer script: {
                       executable: 'Miniconda2-latest-MacOSX-x86_64.sh',
                       args:       ['-b', '-p', "#{HOMEBREW_PREFIX}/miniconda2"],
-		      sudo: 	  true,
+                      sudo: 	     true,
                     }
+
   postflight do
     set_ownership "#{HOMEBREW_PREFIX}/miniconda2"
   end
@@ -26,4 +27,3 @@ cask 'miniconda2' do
     files_in_usr_local
   end
 end
-

--- a/Casks/miniconda2.rb
+++ b/Casks/miniconda2.rb
@@ -23,7 +23,7 @@ cask 'miniconda2' do
   uninstall delete: "#{HOMEBREW_PREFIX}/miniconda2"
 
   caveats do
-    path_environment_variable "#{HOMEBREW_PREFIX}/miniconda2"
+    path_environment_variable "#{HOMEBREW_PREFIX}/miniconda2/bin"
     files_in_usr_local
   end
 end

--- a/Casks/miniconda2.rb
+++ b/Casks/miniconda2.rb
@@ -12,12 +12,18 @@ cask 'miniconda2' do
 
   installer script: {
                       executable: 'Miniconda2-latest-MacOSX-x86_64.sh',
-                      args:       ['-b'],
+                      args:       ['-b', '-p', "#{HOMEBREW_PREFIX}/miniconda2"],
+		      sudo: 	  true,
                     }
+  postflight do
+    set_ownership "#{HOMEBREW_PREFIX}/miniconda2"
+  end
 
-  uninstall delete: '~/miniconda2'
+  uninstall delete: "#{HOMEBREW_PREFIX}/miniconda2"
 
   caveats do
-    path_environment_variable '~/miniconda2/bin'
+    path_environment_variable "#{HOMEBREW_PREFIX}/miniconda2"
+    files_in_usr_local
   end
 end
+


### PR DESCRIPTION
Install hung for me, however miniconda3 install (https://github.com/caskroom/homebrew-cask/blob/master/Casks/miniconda.rb)  did not, but I would prefer to have miniconda2. Updated miniconda2 to reflect the differences with miniconda3.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-versions/pulls
[closed issues]: https://github.com/caskroom/homebrew-versions/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
